### PR TITLE
Fix: GetDonor2FeatVects heavy atoms confusion

### DIFF
--- a/rdkit/Chem/Features/FeatDirUtilsRD.py
+++ b/rdkit/Chem/Features/FeatDirUtilsRD.py
@@ -262,20 +262,18 @@ def GetDonor2FeatVects(conf, featAtoms, scale=1.5) :
   assert len(nbrs) >= 2
 
   hydrogens = []
-  tmp=[]
-  while len(nbrs):
-    nbr = nbrs.pop()
-    if nbr.GetAtomicNum()==1:
+  heavy=[]
+  for nbr in nbrs:
+    if nbr.GetAtomicNum() == 1:
       hydrogens.append(nbr)
     else:
-      tmp.append(nbr)
-  nbrs = tmp
-      
+      heavy.append(nbr)     
+  
   if len(nbrs) == 2:
     # there should be no hydrogens in this case
     assert len(hydrogens) == 0
     # in this case the direction is the opposite of the average vector of the two neighbors
-    bvec = _findAvgVec(conf, cpt, nbrs)
+    bvec = _findAvgVec(conf, cpt, heavy)
     bvec *= (-1.0*scale)
     bvec += cpt
     return ((cpt, bvec),), 'linear'
@@ -296,7 +294,7 @@ def GetDonor2FeatVects(conf, featAtoms, scale=1.5) :
       return ((cpt, bvec),), 'linear'
     else :
       # we have a non-planar configuration - we will assume sp3 and compute a second direction vector
-      ovec = _findAvgVec(conf, cpt, nbrs)
+      ovec = _findAvgVec(conf, cpt, heavy)
       ovec *= (-1.0*scale)
       ovec += cpt
       return ((cpt, bvec), (cpt, ovec),), 'linear'


### PR DESCRIPTION
Dear Greg,

First of all, as is the first time I write you, I want to present me. I am starting my PhD of bioinformatics in Barcelona, and I am using the RDKit library in some aspects of my work.

ConcreteIy, I am using the FeatDirUtilsRD to calculate the feature vectors of a feature and I have found some apparent  mistakes in the function GetDonor2FeatVects. 
 
I think that there is a confusion with the "nbrs" list. The first thing that the function does is to create a "hydrogens" list to use it after. But after the while loop, the list "nbrs" doesn't contain anymore the all neighbours (including hydrogens) of the donor, but only the heavy neighbour atoms. The "nbrs" list is used after the while with two meanings: as if it contained all the neighbours or only the heavy ones (I think here is the confusion).

I propose to change the "while" loop by a "for" one, creating a "heavy" list with the heavy neighbours atoms and keeping the meaning of "nbrs" list as all the neighbours (including hydrogens). After the loop, I have changed the "nbrs" list by the "heavy" one where I find that is correct.

I would be grateful if you could review my proposed changes and say me if I am right with these.

Many thanks,

José Emilio Sánchez